### PR TITLE
Added ACCEPT_EULA environment variable, and CFN parameter

### DIFF
--- a/templates/services/xl-deploy.template
+++ b/templates/services/xl-deploy.template
@@ -92,6 +92,11 @@ Parameters:
     Description: The ARN of the SSL certificate used to secure internet access to the XebiaLabs DevOps Platform
     Type: String
     Default: ':default'
+  AcceptEula:
+    Description: Do you accept the XebiaLabs EULA (Allowed value 'yes')
+    Type: String
+    AllowedPattern: '^yes$'
+
 # Mappings:
 
 Conditions:
@@ -102,6 +107,7 @@ Conditions:
   ShouldLaunchCluster: !Not [ !Equals [ !Ref ClusterMode, 'default' ] ]
   LicenseProvided: !Not [ !Equals [ !Ref License, 'trial' ] ]
   SslCertificateProvided: !Not [ !Equals [ !Ref SslCertificateArn, ':default' ] ]
+  EulaAccepted: !Equals [ !Ref AcceptEula, 'yes' ]
 Resources:
   CreateXLDeployDatabase:
     Type: Custom::CreateXLDeployDatabase
@@ -171,6 +177,11 @@ Resources:
           - LicenseProvided
           - !Ref License
           - !Ref AWS::NoValue
+        - Name: ACCEPT_EULA
+          Value: !If
+          - EulaAccepted
+          - 'Y'
+          - 'N'
         Hostname: xl-deploy
         MountPoints:
         - ContainerPath: "/opt/xebialabs/xl-deploy-server/repository"

--- a/templates/services/xl-release.template
+++ b/templates/services/xl-release.template
@@ -92,6 +92,10 @@ Parameters:
     Description: The ARN of the SSL certificate used to secure internet access to the XebiaLabs DevOps Platform
     Type: String
     Default: ':default'
+  AcceptEula:
+    Description: Do you accept the XebiaLabs EULA (Allowed value 'yes')
+    Type: String
+    AllowedPattern: '^yes$'
 
 # Mappings: 
 
@@ -103,6 +107,7 @@ Conditions:
   ShouldLaunchCluster: !Not [ !Equals [ !Ref ClusterMode, 'default' ] ]
   LicenseProvided: !Not [ !Equals [ !Ref License, 'trial' ] ]
   SslCertificateProvided: !Not [ !Equals [ !Ref SslCertificateArn, ':default' ] ]
+  EulaAccepted: !Equals [ !Ref AcceptEula, 'yes' ]
 Resources:
   CreateXLReleaseDatabase:
     Type: Custom::CreateXLReleaseDatabase
@@ -196,6 +201,11 @@ Resources:
           - LicenseProvided
           - !Ref License
           - !Ref AWS::NoValue
+        - Name: ACCEPT_EULA
+          Value: !If
+          - EulaAccepted
+          - 'Y'
+          - 'N'
         Hostname: xl-release
         MountPoints:
         - ContainerPath: "/opt/xebialabs/xl-release-server/repository"

--- a/templates/xl-devops-platform-master.template
+++ b/templates/xl-devops-platform-master.template
@@ -50,6 +50,7 @@ Metadata:
           - XLReleasePassword
           - XLReleaseClusterMode
           - XLReleaseLicense
+          - AcceptEula
       - Label:
           default: AWS Quick Start Configuration
         Parameters:
@@ -82,6 +83,8 @@ Metadata:
         default: XL Deploy license
       XLReleaseLicense:
         default: XL Release license
+      AcceptEula:
+        default: Accept the XebiaLabs EULA
       SslCertificateArn:
         default: SSL certificate arn
       EnvironmentName:
@@ -166,6 +169,10 @@ Parameters:
     AllowedValues:
       - true
       - false
+  AcceptEula:
+    Description: Do you accept the XebiaLabs EULA (Allowed value 'yes')
+    Type: String
+    AllowedPattern: '^yes$'
   SslCertificateArn:
     Description: >-
       The ARN of the SSL certificate used to secure internet access to the
@@ -414,6 +421,7 @@ Resources:
         XLReleaseLicense: !Ref XLReleaseLicense
         XLDeployLicense: !Ref XLDeployLicense
         SslCertificateArn: !Ref SslCertificateArn
+        AcceptEula: !Ref AcceptEula
 Outputs:
   XLDeployURL:
     Description: The URL where XL Deploy is reachable

--- a/templates/xl-devops-platform.template
+++ b/templates/xl-devops-platform.template
@@ -51,6 +51,7 @@ Metadata:
       - XLDeployClusterMode
       - XLDeployLicense
       - MountPoint
+      - AcceptEula
     - Label:
         default: AWS Quick Start Configuration
       Parameters:
@@ -83,6 +84,8 @@ Metadata:
         default: XL Deploy license
       XLReleaseLicense:
         default: XL Release license
+      AcceptEula:
+        default: Accept the XebiaLabs EULA
       SslCertificateArn:
         default: SSL certificate arn
       EnvironmentName:
@@ -173,6 +176,10 @@ Parameters:
     AllowedValues: 
     - true
     - false
+  AcceptEula:
+    Description: Do you accept the XebiaLabs EULA (Allowed value 'yes')
+    Type: String
+    AllowedPattern: '^yes$'
   SslCertificateArn:
     Description: The ARN of the SSL certificate used to secure internet access to the XebiaLabs DevOps Platform
     Type: String
@@ -412,6 +419,7 @@ Resources:
         ClusterMode: !Ref XLReleaseClusterMode
         UseExternalDB: !Ref UseExternalDB
         License: !Ref XLReleaseLicense
+        AcceptEula: !Ref AcceptEula
   XLDeployApplication:
     Type: AWS::CloudFormation::Stack
     Condition: ShouldInstallXLDeploy
@@ -438,6 +446,7 @@ Resources:
         ClusterMode: !Ref XLDeployClusterMode
         UseExternalDB: !Ref UseExternalDB
         License: !Ref XLDeployLicense
+        AcceptEula: !Ref AcceptEula
 Outputs:
   XLDeployURL:
     Description: The URL where XL Deploy is reachable


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The new XL DevOps platform containers require the `ACCEPT_EULA` environment variable to be present to indicate the user has accepted the EULA. This PR ensures that the containers can boot, and the user explicitly agrees to the EULA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
